### PR TITLE
docs: expand conf matrix phrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Computer vision tools
 Tools for computer vision projects to automate workflows
 
-TODO: try also exporting conf matrix results as csv when made, then just reading from csv to sum
+TODO: try also exporting confusion matrix results as csv when made, then just reading from csv to sum


### PR DESCRIPTION
## Summary
- expand "conf matrix" wording to "confusion matrix" in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689852da91b8832f82a6cd1f066dc6fc