### PR TITLE
Add dataset rebalancer utility and tests

### DIFF
--- a/dataset_rebalancer.py
+++ b/dataset_rebalancer.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+from typing import Iterable, List
+
+
+def rebalance_dataset(source: Path | str, destination: Path | str, fraction: float = 0.25) -> List[str]:
+    """Copy a fraction of files from source to destination.
+
+    Files are selected deterministically by sorting the source directory and
+    copying every Nth file where N is 1/fraction.
+
+    Returns a list of file names that were copied.
+    """
+    source_path = Path(source)
+    dest_path = Path(destination)
+    dest_path.mkdir(parents=True, exist_ok=True)
+
+    files = sorted([p for p in source_path.iterdir() if p.is_file()])
+    if not files:
+        return []
+
+    step = max(int(round(1 / fraction)), 1)
+    selected = files[step - 1 :: step]
+
+    for file_path in selected:
+        shutil.copy2(file_path, dest_path / file_path.name)
+
+    return [f.name for f in selected]

--- a/tests/test_dataset_rebalancer.py
+++ b/tests/test_dataset_rebalancer.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+# Ensure the project root is on sys.path for direct execution of `pytest`
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from dataset_rebalancer import rebalance_dataset
+
+
+def populate_dir(directory: Path, count: int) -> None:
+    for i in range(count):
+        (directory / f"file_{i}.txt").write_text("data")
+
+
+def test_rebalance_copies_quarter_with_stable_selection(tmp_path):
+    source = tmp_path / "source"
+    dest1 = tmp_path / "dest1"
+    dest2 = tmp_path / "dest2"
+    source.mkdir()
+
+    populate_dir(source, 20)
+
+    copied1 = rebalance_dataset(source, dest1)
+    copied2 = rebalance_dataset(source, dest2)
+
+    assert len(copied1) == 5
+    assert len(list(dest1.iterdir())) == 5
+    assert copied1 == copied2
+    assert sorted(p.name for p in dest1.iterdir()) == sorted(copied1)


### PR DESCRIPTION
## Summary
- Implement deterministic dataset rebalancer that copies a configurable fraction of files
- Add unit test validating quarter-sized, stable selection across runs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68985455853c832f83cdec4524ffa234